### PR TITLE
Solve btn redundant styles and Add bg-colors classes to typography file

### DIFF
--- a/dist/typography.html
+++ b/dist/typography.html
@@ -36,10 +36,14 @@
     </div>
     <div class="p-4">
       <h1 class="text-c100 text-xl"> Three Type Of Buttons </h1>
+      <p>use the .btn-{size} classes with <span class="text-c200 font-bold text-lg"> a </span> or <span class="text-c200 font-bold text-lg">button</span> elements 
+      <p>choose the preferd size and don't forget to specify the background color via adding the .bg-{color} class like <span class="text-c400 font-bold">.bg-c100</span>
+      <br> *Don't forget to check the background colors section</p>
+     
       <div class="mt-4">
-        <button class="btn-lg"> Large Btn </button>
-        <button class="btn-md"> Meduim Btn </button>
-        <button class="btn-sm"> Small Btn </button>
+        <button class="btn-lg bg-c300">(.btn-lg)</button>
+        <button class="btn-md bg-c200">(.btn-md)</button>
+        <button class="btn-sm bg-c400">(.btn-sm)</button>
       </div>
     </div>
     <div class="p-4">

--- a/dist/typography.html
+++ b/dist/typography.html
@@ -8,6 +8,21 @@
   </head>
   <body>
     <div class="p-4">
+      <h1 class="text-c100 text-xl">Background Colors</h1>
+      <div class="mt-4">
+        <div class="bg-c000 my-2 h-7 w-48 text-c100 text-center rounded-md border border-black">.bg-c000</div>
+        <div class="bg-c100 my-2 h-7 w-48 text-c000 text-center rounded-md border border-black">.bg-c100</div>
+        <div class="bg-c200 my-2 h-7 w-48 text-c000 text-center rounded-md border border-black">.bg-c200</div>
+        <div class="bg-c300 my-2 h-7 w-48 text-c000 text-center rounded-md border border-black">.bg-c300</div>        
+        <div class="bg-c400 my-2 h-7 w-48 text-c000 text-center rounded-md border border-black">.bg-c400</div>
+        <div class="bg-c500 my-2 h-7 w-48 text-c000 text-center rounded-md border border-black">.bg-c500</div>
+        <div class="bg-c600 my-2 h-7 w-48 text-c000 text-center rounded-md border border-black">.bg-c600</div>
+        <div class="bg-c700 my-2 h-7 w-48 text-c000 text-center rounded-md border border-black">.bg-c700</div>
+        <div class="bg-c800 my-2 h-7 w-48 text-c100 text-center rounded-md border border-black">.bg-c800</div>
+      </div>
+    </div>
+    
+    <div class="p-4">
       <h1 class="text-c100 text-xl">Font Colors</h1>
       <div class="mt-4">
         <h1 class="text-lg font-bold text-c100">.text-c100</h1>

--- a/dist/typography.html
+++ b/dist/typography.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="./assets/css/main.css" />
     <title>Document</title>
   </head>
-  <body>
+  <body class="font-body">
     <div class="p-4">
       <h1 class="text-c100 text-xl">Background Colors</h1>
       <div class="mt-4">
@@ -36,7 +36,7 @@
     </div>
     <div class="p-4">
       <h1 class="text-c100 text-xl"> Three Type Of Buttons </h1>
-      <p>use the .btn-{size} classes with <span class="text-c200 font-bold text-lg"> a </span> or <span class="text-c200 font-bold text-lg">button</span> elements 
+      <p>use the .btn-{size} classes with <span class="text-c200 font-bold text-lg"> a </span> or <span class="text-c200 font-bold text-lg">button</span> elements  
       <p>choose the preferd size and don't forget to specify the background color via adding the .bg-{color} class like <span class="text-c400 font-bold">.bg-c100</span>
       <br> *Don't forget to check the background colors section</p>
      

--- a/package-lock.json
+++ b/package-lock.json
@@ -511,6 +511,21 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
       "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ=="
     },
+    "has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "requires": {
+        "ansi-regex": "^2.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+        }
+      }
+    },
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -605,6 +620,11 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
+    },
+    "js-base64": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.5.2.tgz",
+      "integrity": "sha512-Vg8czh0Q7sFBSUMWWArX/miJeBWYBPpdU/3M/DKSaekLMqrqVPaedp+5mZhie/r0lgrcaYBfwXatEew6gwgiQQ=="
     },
     "js-yaml": {
       "version": "3.13.1",
@@ -865,6 +885,82 @@
         "pretty-hrtime": "^1.0.3",
         "read-cache": "^1.0.0",
         "yargs": "^15.0.2"
+      }
+    },
+    "postcss-extend": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/postcss-extend/-/postcss-extend-1.0.5.tgz",
+      "integrity": "sha1-XqmL94e6PKz030YJdD+AqDOx0Oc=",
+      "requires": {
+        "postcss": "^5.0.4"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+        },
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "requires": {
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
+          },
+          "dependencies": {
+            "supports-color": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+              "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+            }
+          }
+        },
+        "has-flag": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+        },
+        "postcss": {
+          "version": "5.2.18",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
+          "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+          "requires": {
+            "chalk": "^1.1.3",
+            "js-base64": "^2.1.9",
+            "source-map": "^0.5.6",
+            "supports-color": "^3.2.3"
+          }
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "3.2.3",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+          "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+          "requires": {
+            "has-flag": "^1.0.0"
+          }
+        }
       }
     },
     "postcss-functions": {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "@fullhuman/postcss-purgecss": "^2.1.2",
     "autoprefixer": "^9.7.6",
     "postcss-cli": "^7.1.0",
+    "postcss-extend": "^1.0.5",
     "postcss-import": "^12.0.1",
     "tailwindcss": "^1.2.0"
   },

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -2,6 +2,7 @@ module.exports = {
   plugins: [
     // ...
     require('postcss-import'),
+    require('postcss-extend'),
     require('tailwindcss'),
     require('autoprefixer')
     // require('@fullhuman/postcss-purgecss')({

--- a/src/css/global.css
+++ b/src/css/global.css
@@ -1,5 +1,5 @@
 %btn {
-  @apply leading-none text-base text-c100 font-extrabold bg-c300 px-16;
+  @apply leading-none text-base text-c100 font-extrabold px-16;
 }
 
 .btn-lg {

--- a/src/css/global.css
+++ b/src/css/global.css
@@ -16,6 +16,9 @@
   @extend %btn;
   @apply py-5;
 }
+.btn-card {
+  @apply text-base font-extrabold bg-c300 py-6 px-24 text-c100;
+}
 .underline {
   border-bottom-color: currentColor;
   border-bottom-style: solid;

--- a/src/css/global.css
+++ b/src/css/global.css
@@ -1,19 +1,21 @@
+%btn {
+  @apply leading-none text-base text-c100 font-extrabold bg-c300 px-16;
+}
+
 .btn-lg {
-  @apply leading-none text-base text-c100 font-extrabold bg-c300 py-8 px-16;
+  @extend %btn;
+  @apply py-8;
 }
 
 .btn-md {
-  @apply leading-none text-base text-c100 font-extrabold bg-c300 py-7 px-16;
+  @extend %btn;
+  @apply py-7;
 }
 
 .btn-sm {
-  @apply leading-none text-base text-c100 font-extrabold bg-c300 py-5 px-16;
+  @extend %btn;
+  @apply py-5;
 }
-
-.btn-card {
-  @apply text-base font-extrabold bg-c300 py-6 px-24 text-c100;
-}
-
 .underline {
   border-bottom-color: currentColor;
   border-bottom-style: solid;


### PR DESCRIPTION
https://app.clickup.com/t/6890w7
https://abudzohair.charity.m3ntorship.com/

- Add postcss-extend plugin 
- Add global btn styles 
- Add bg-colors classes to the typography file
- check the typography file and choose the color you want to use, then just copy the className of the color 
- Don't forget to run "npm i"