### PR TITLE
use environment-based strapi url

### DIFF
--- a/.github/workflows/deploy-firebase-live.yml
+++ b/.github/workflows/deploy-firebase-live.yml
@@ -22,6 +22,7 @@ jobs:
         run: npm run build
         env:
           NODE_ENV: ci
+          REACT_APP_STRAPI_URL: http://charity-cms.m3ntorship.net
       - name: GitHub Action for Firebase
         uses: w9jds/firebase-action@v1.3.0
         with:

--- a/.github/workflows/deploy-firebase-user.yml
+++ b/.github/workflows/deploy-firebase-user.yml
@@ -23,6 +23,7 @@ jobs:
         run: npm run build
         env:
           NODE_ENV: ci
+          REACT_APP_STRAPI_URL: http://charity-cms-dev.m3ntorship.net
       - name: GitHub Action for Firebase
         uses: w9jds/firebase-action@v1.3.0
         env:

--- a/src/clients/charity.js
+++ b/src/clients/charity.js
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import { create } from 'axios';
 
 export const charityAPI = create({
-  baseURL: 'http://charity-cms.m3ntorship.net'
+  baseURL: process.env.STRAPI_URL
 });
 
 export const useCharityAPI = url => {


### PR DESCRIPTION
- [x] use environment-based strapi url
    - `locally` it will be taken from the environment variable `REACT_APP_STRAPI_URL`
    - `user site` (https://<username>.charity.m3ntorship.com) will **ALL** connect and share  [http://charity-cms-dev.m3ntorship.net](http://charity-cms-dev.m3ntorship.net). the admin panel path is `/sudo`
    - `production/live` (https://charity.m3ntorship.com) will connect to live heroku strapi at (http://charity-cms.m3ntorship.net)